### PR TITLE
CASMPET-4707: Run rego tests in gatekeeper-policy-library

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -25,6 +25,12 @@ pipeline {
     }
 
     stages {
+        stage("Test") {
+            steps {
+                sh "make rego_test"
+            }
+        }
+
         stage("Build") {
             parallel {
                 stage("Charts") {

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ CHART_VERSION_2 ?= local
 CHART_VERSION_3 ?= local
 CHART_VERSION_4 ?= local
 
+OPA_IMAGE ?= openpolicyagent/opa:0.31.0
+
+
+all: charts rego_test
 charts: chart1 chart2 chart3 chart4
 
 chart1:
@@ -47,3 +51,6 @@ chart3:
 chart4:
 	helm dep up ${CHART_PATH}/${CHART_NAME_4}
 	helm package ${CHART_PATH}/${CHART_NAME_4} -d ${CHART_PATH}/.packaged --version ${CHART_VERSION_4}
+
+rego_test:
+	docker run -v ${PWD}/${CHART_PATH}/gatekeeper-policy-library/regos:/test ${OPA_IMAGE} test -v /test

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ If you're looking to build out a chart for your service, look instead at [the Cr
 
 ## Testing charts here and elsewhere
 
-Please see the [cray-chartsutil](https://stash.us.cray.com/projects/CLOUD/repos/cray-chartsutil/browse) for more info on testing out charts.
+Run `make rego_test`.


### PR DESCRIPTION
The rego tests in the gatekeeper-policy-libarary chart will be run
during the build.