### PR TITLE
CASMPET-4711: Change psp-pods-allowed-user-ranges to ignore istio

### DIFF
--- a/kubernetes/gatekeeper-constraints/templates/users.constraint.yaml
+++ b/kubernetes/gatekeeper-constraints/templates/users.constraint.yaml
@@ -19,6 +19,8 @@ spec:
     # namespaces:
     #   - "production"  parameters:
   parameters:
+    allowedImages:
+{{ .Values.allowedImages | toYaml | indent 6 }}
     runAsUser:
       rule: {{ index .Values "constraints" "users" "variables" $profile "runAsUser" "rule" }}
       ranges:

--- a/kubernetes/gatekeeper-constraints/values.yaml
+++ b/kubernetes/gatekeeper-constraints/values.yaml
@@ -7,6 +7,8 @@
 
 excludedNamespaces:
   - kube-system
+allowedImages:
+  - gcr.io/vshasta-cray/istio/proxyv2:1.6.13-cray1-20210202183713_549528c5da
 constraints:
   allow-privilege-escalation-container:
     profile: restricted

--- a/kubernetes/gatekeeper-policy-library/regos/capabilities/capabilities.src.rego
+++ b/kubernetes/gatekeeper-policy-library/regos/capabilities/capabilities.src.rego
@@ -2,12 +2,14 @@ package capabilities
 
 violation[{"msg": msg}] {
   container := input.review.object.spec.containers[_]
+  container.image != "gcr.io/vshasta-cray/istio/proxyv2:1.6.13-cray1-20210202183713_549528c5da"
   has_disallowed_capabilities(container)
   msg := sprintf("container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, get_default(input.parameters, "allowedCapabilities", "NONE")])
 }
 
 violation[{"msg": msg}] {
   container := input.review.object.spec.containers[_]
+  container.image != "gcr.io/vshasta-cray/istio/proxyv2:1.6.13-cray1-20210202183713_549528c5da"
   missing_drop_capabilities(container)
   msg := sprintf("container <%v> is not dropping all required capabilities. Container must drop all of %v", [container.name, input.parameters.requiredDropCapabilities])
 }
@@ -16,12 +18,14 @@ violation[{"msg": msg}] {
 
 violation[{"msg": msg}] {
   container := input.review.object.spec.initContainers[_]
+  container.image != "gcr.io/vshasta-cray/istio/proxyv2:1.6.13-cray1-20210202183713_549528c5da"
   has_disallowed_capabilities(container)
   msg := sprintf("init container <%v> has a disallowed capability. Allowed capabilities are %v", [container.name, get_default(input.parameters, "allowedCapabilities", "NONE")])
 }
 
 violation[{"msg": msg}] {
   container := input.review.object.spec.initContainers[_]
+  container.image != "gcr.io/vshasta-cray/istio/proxyv2:1.6.13-cray1-20210202183713_549528c5da"
   missing_drop_capabilities(container)
   msg := sprintf("init container <%v> is not dropping all required capabilities. Container must drop all of %v", [container.name, input.parameters.requiredDropCapabilities])
 }

--- a/kubernetes/gatekeeper-policy-library/templates/users/users.template.yaml
+++ b/kubernetes/gatekeeper-policy-library/templates/users/users.template.yaml
@@ -10,6 +10,11 @@ spec:
       validation:
         openAPIV3Schema:
           properties:
+            allowedImages:
+              type: array
+              # default: [] -- Why doesn't this work?
+              items:
+                type: string
             runAsUser:
               type: object
               properties:


### PR DESCRIPTION
Gatekeeper's psp-pods-allowed-user-ranges Constraint is flagging
the istio-init and istio-proxy containers because they're configured to
run as root.
istio-init & istio-proxy need to run as root because they do stuff with
iptables when they run.