### PR TITLE
CASMPET-4712: Expand range for allowed users/groups

### DIFF
--- a/kubernetes/gatekeeper-constraints/values.yaml
+++ b/kubernetes/gatekeeper-constraints/values.yaml
@@ -120,14 +120,14 @@ constraints:
         rule: "MustRunAs"
         ranges:
           - min: 1
-            max: 1000
+            max: 65535
       restricted-transition:
         enforcementAction: deny
         enabled: true
         rule: "MustRunAs"
         ranges:
           - min: 1
-            max: 1000
+            max: 65535
       privileged:
         enforcementAction: deny
         enabled: false
@@ -137,7 +137,7 @@ constraints:
         rule: "MustRunAs"
         ranges:
           - min: 1
-            max: 1000
+            max: 65535
   host-filesystem:
     profile: restricted
     variables:
@@ -297,13 +297,13 @@ constraints:
         runAsUser:
           rule: MustRunAsNonRoot
           ranges:
-            - min: 100
-              max: 200
+            - min: 1
+              max: 65535
         runAsGroup:
           rule: RunAsAny
           ranges:
-            - min: 100
-              max: 200
+            - min: 1
+              max: 65535
         supplementalGroups:
           rule: MustRunAs #
           ranges:
@@ -320,13 +320,13 @@ constraints:
         runAsUser:
           rule: RunAsAny
           ranges:
-            - min: 100
-              max: 200
+            - min: 1
+              max: 65535
         runAsGroup:
           rule: RunAsAny
           ranges:
-            - min: 100
-              max: 200
+            - min: 1
+              max: 65535
         supplementalGroups:
           rule: MustRunAs #
           ranges:
@@ -343,13 +343,13 @@ constraints:
         runAsUser:
           rule: RunAsAny
           ranges:
-            - min: 100
-              max: 200
+            - min: 1
+              max: 65535
         runAsGroup:
           rule: RunAsAny
           ranges:
-            - min: 100
-              max: 200
+            - min: 1
+              max: 65535
         supplementalGroups:
           rule: RunAsAny
           ranges:
@@ -366,13 +366,13 @@ constraints:
         runAsUser:
           rule: MustRunAsNonRoot
           ranges:
-            - min: 100
-              max: 200
+            - min: 1
+              max: 65535
         runAsGroup:
           rule: RunAsAny
           ranges:
-            - min: 100
-              max: 200
+            - min: 1
+              max: 65535
         supplementalGroups:
           rule: MustRunAs #
           ranges:


### PR DESCRIPTION
### Summary and Scope

We've recently changed the cray-service chart to default to setting
the user and group to run as to 65534 (the nobody user on the K8s
NCNs). While we've decided that this user is OK to run as the
Gatekeeper policy would still reject this since it's outside the
default range.

The range is now set to 1 - 65535. 0 is not in the allowed range
because that UID has root access.

### Summary and Scope

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? New feature

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4712

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run? N
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Made this change then verified in the Gatekeeper Policy Manager that it was looking for different values (the input values are shown in the validation results and there's currently many failures).

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? No
ANY OTHER SPECIAL CONSIDERATIONS? None

Requires: None
