### PR TITLE
CASMPET-4716: Clean up excludedNamespaces

### DIFF
--- a/kubernetes/gatekeeper-constraints/values.yaml
+++ b/kubernetes/gatekeeper-constraints/values.yaml
@@ -6,9 +6,7 @@
 # CONSTRAINTS TO BE APPLIED
 
 excludedNamespaces:
-  - loftsman
   - kube-system
-  - istio
 constraints:
   allow-privilege-escalation-container:
     profile: restricted


### PR DESCRIPTION
### Summary and Scope

The `loftsman` namespace is removed from excludedNamespaces. There's
nothing in it so there's no need to exclude it.

The `istio` namespace is removed from excludedNamespaces. We don't
create an `istio` namespace. I can't think of a reason that the 2
istio-related namespaces that we do have should be excluded from
Gatekeeper checks.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? N/A

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4716

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

After applying the chart I checked the Gaekeeper Policy Manager and saw that it had updated the Excluded Namespaces to match the change.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? No
ANY OTHER SPECIAL CONSIDERATIONS? None

Requires: None
