### PR TITLE
CASMPET-4717: Bump versions to prep for CSM 1.2 release.

### DIFF
--- a/kubernetes/gatekeeper-constraints/Chart.yaml
+++ b/kubernetes/gatekeeper-constraints/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.16.0
 description: A Helm chart for Kubernetes
 name: gatekeeper-constraints
 type: application
-version: 0.2.0
+version: 0.4.0

--- a/kubernetes/gatekeeper-policy-library/Chart.yaml
+++ b/kubernetes/gatekeeper-policy-library/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.16.0
 description: A Helm chart for Kubernetes
 name: gatekeeper-policy-library
 type: application
-version: 0.2.0
+version: 0.4.0

--- a/kubernetes/gatekeeper-policy-manager/Chart.yaml
+++ b/kubernetes/gatekeeper-policy-manager/Chart.yaml
@@ -6,6 +6,6 @@ description: A Helm chart for OPA Gatekeeper Policy Manager
 
 type: application
 
-version: 1.0.0
+version: 1.2.0
 appVersion: 0.4.0
 ---

--- a/kubernetes/gatekeeper/Chart.yaml
+++ b/kubernetes/gatekeeper/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for Gatekeeper
 name: gatekeeper
 keywords:
   - open policy agent
-version: 1.2.0
+version: 1.4.0
 home: https://github.com/open-policy-agent/gatekeeper
 sources:
   - https://github.com/open-policy-agent/gatekeeper.git


### PR DESCRIPTION
Changes in this release:

* CASMPET-4140: Remove hardcoded namespaces
* CASMPET-4139: Remove imagesHost references
* CASMPET-4140: Fix namespace issues
* CASMPET-4707: Run rego tests in gatekeeper-policy-library
* CASMPET-4712: Expand range for allowed users/groups
* CASMPET-4716: Clean up excludedNamespaces

There hasn't been a release of this since moving to github, the latest
release was in CSM-1.0.
Leaving room for a 1.1 version bump in case we need it.