### PR TITLE
CASMTRIAGE-2849: gatekeeper hook use curl

### DIFF
--- a/charts/gatekeeper/Chart.yaml
+++ b/charts/gatekeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gatekeeper
-version: 1.5.0
+version: 1.5.1
 description: A Helm chart for Gatekeeper
 keywords:
   - open policy agent
@@ -22,6 +22,6 @@ annotations:
   artifacthub.io/images: |
     - name: gatekeeper-policy-manager
       image: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/gatekeeper:v3.1.1
-    - name: kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+    - name: curl
+      image: curlimages/curl:7.80.0
   artifacthub.io/license: MIT

--- a/charts/gatekeeper/templates/wait-jobs.yaml
+++ b/charts/gatekeeper/templates/wait-jobs.yaml
@@ -20,8 +20,8 @@ spec:
       serviceAccountName: gatekeeper-admin
       containers:
         - name: wait
-          image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
-          imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
+          image: {{ .Values.curl.image.repository }}:{{ .Values.curl.image.tag }}
+          imagePullPolicy: {{ .Values.curl.image.pullPolicy }}
           command:
             - '/bin/sh'
           args:

--- a/charts/gatekeeper/values.yaml
+++ b/charts/gatekeeper/values.yaml
@@ -30,8 +30,8 @@ resources:
 webhook:
   failurePolicy: Ignore
 
-kubectl:
+curl:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    repository: curlimages/curl
+    tag: 7.80.0
     pullPolicy: IfNotPresent


### PR DESCRIPTION
### Summary and Scope

The gatekeeper chart was failing to deploy properly because the
hook image configured to use kubectl but it calls curl. The fix
is to change the hook to use an image with curl in it.

The curl image used is chosen to comply with the
"Referencing common images" section in CASM-2670.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? Critical bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y

### Issues and Related PRs

* Resolves CASMTRIAGE-2849

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     N.  If not, Why? The old version doesn't work.
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER)  Manual.
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed the fixed chart, checked the image was correct. Verified the job finished and the chart install is now successful.

### Risks and Mitigations

Requires: None
