### PR TITLE
CASMINST-4081 Update docker.io/curlimages/curl to resolve CVEs.

### DIFF
--- a/charts/gatekeeper/Chart.yaml
+++ b/charts/gatekeeper/Chart.yaml
@@ -1,6 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: v2
 name: gatekeeper
-version: 1.5.1
+version: 1.5.2
 description: A Helm chart for Gatekeeper
 keywords:
   - open policy agent
@@ -23,5 +46,5 @@ annotations:
     - name: gatekeeper-policy-manager
       image: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/gatekeeper:v3.1.1
     - name: curl
-      image: curlimages/curl:7.80.0
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.81.0
   artifacthub.io/license: MIT

--- a/charts/gatekeeper/values.yaml
+++ b/charts/gatekeeper/values.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 nameOverride: ""
 
 replicas: 3
@@ -32,6 +55,6 @@ webhook:
 
 curl:
   image:
-    repository: curlimages/curl
-    tag: 7.80.0
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl
+    tag: 7.81.0
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

Update the OPA gatekeeper chart curl image to resolve known CVEs.

## Issues and Related PRs

* Resolves CASMINST-4081

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

It was confirmed that the gatekeeper-1.5.2 chart was installed and that the job/wait-for-opa-gatekeeper-webhook completed using the expected Artifactory docker.io/curlimages/curl:7.81.0 image.

````
Containers:
  wait:
    Container ID:  containerd://1402833eebad63045e5f53508ad1617d8e00377d248be276afae51b3fee93b0e
    Image:         gcr.io/vsha-rnoska-35682334251619627/curlimages/curl:7.81.0
    Image ID:      gcr.io/vsha-rnoska-35682334251619627/curlimages/curl@sha256:6889bce57e082881f1b616122623575e912b1f1af6f36f0969fb4d555d2dd668
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/sh
    Args:
      -x
      -c
      while ! curl -kv https://gatekeeper-webhook-service.gatekeeper-system.svc; do sleep 5; done
    State:          Terminated
      Reason:       Completed
````

## Risks and Mitigations

None

