### PR TITLE
CASMPET-4947: Update auth gateways for cmn seperation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ dep-up:
 test:
 	docker run --rm \
 		-v ${PWD}/charts:/apps \
-		${HELM_UNITTEST_IMAGE} -3 \
+		${HELM_UNITTEST_IMAGE} \
 		gatekeeper \
 		gatekeeper-constraints \
 		gatekeeper-policy-library \

--- a/charts/gatekeeper-policy-manager/Chart.yaml
+++ b/charts/gatekeeper-policy-manager/Chart.yaml
@@ -1,7 +1,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 apiVersion: v2
 name: gatekeeper-policy-manager
-version: 1.3.0
+version: 1.3.1
 description: A Helm chart for OPA Gatekeeper Policy Manager
 keywords:
   - gatekeeper-policy-manager

--- a/charts/gatekeeper-policy-manager/templates/ingress.yaml
+++ b/charts/gatekeeper-policy-manager/templates/ingress.yaml
@@ -11,8 +11,10 @@ metadata:
   labels:
     app: gatekeeper-policy-manager
 spec:
+  {{- with .Values.global.authGateways }}
   gateways:
-  - {{ .Values.global.authGateway }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   hosts:
   - {{ (index .Values "gatekeeper-policy-manager" "externalAuthority") }}
   http:

--- a/charts/gatekeeper-policy-manager/values.yaml
+++ b/charts/gatekeeper-policy-manager/values.yaml
@@ -1,7 +1,9 @@
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
 global:
-  authGateway: services/services-gateway
+  authGateways:
+  - services/services-gateway
+  - services/customer-admin-gateway
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/quay.io/sighup/gatekeeper-policy-manager


### PR DESCRIPTION
## Summary and Scope

This allows for the service to be accessible through the cmn gateway and not just the istio-ingressgateway which will be externally disabled soon.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-4947](https://jira-pro.it.hpe.com:8443/browse/CASMPET-4947)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * mug
  * dorian

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? n

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

